### PR TITLE
Django 4.x compatibility: Remove NullBooleanField

### DIFF
--- a/rest_framework_serializer_field_permissions/fields.py
+++ b/rest_framework_serializer_field_permissions/fields.py
@@ -77,11 +77,6 @@ class BooleanField(PermissionMixin, fields.BooleanField):
 
 
 # pylint: disable=missing-docstring
-class NullBooleanField(PermissionMixin, fields.NullBooleanField):
-    pass
-
-
-# pylint: disable=missing-docstring
 class CharField(PermissionMixin, fields.CharField):
     pass
 


### PR DESCRIPTION
## Why

Django has removed NullBooleanField: https://code.djangoproject.com/ticket/31369

## What

Remove NullBooleanField from this library to make it compatible with Django 4.x release.